### PR TITLE
support JsonPathConfigs

### DIFF
--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -74,13 +74,16 @@ type ProbeMarkerPolicy struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Patch annotations pod.annotations
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Patch JSONPath
+	JsonPathConfigs []JSONPathConfig `json:"jsonPathConfigs,omitempty"`
 }
 
 type FieldType string
 
 type JSONPathConfig struct {
-	JSONPath  string    `json:"jsonPath"`
-	FieldType FieldType `json:"fieldType"` // The data type of the extracted result
+	JSONPath  string      `json:"jsonPath"`  // JSONPath 表达式
+	FieldType FieldType   `json:"fieldType"` // 提取结果的数据类型
+	Value     interface{} `json:"value"`     // 填的值
 }
 
 func (s *StorageConfig) StoreData(factory StorageFactory, data string) error {

--- a/pkg/store/in_kube.go
+++ b/pkg/store/in_kube.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/magicsong/kidecar/pkg/constants"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/magicsong/kidecar/api"
@@ -216,9 +217,14 @@ func generatePatch(data string, myconfig *InKubeConfig) []jsonpatch.JsonPatchOpe
 				patch = append(patch, jsonpatch.NewOperation("replace", "/metadata/labels/"+rfc6901Encoder.Replace(key), value))
 			}
 		}
-		if len(policy.GameServerOpsState) > 0 {
-			patch = append(patch, jsonpatch.NewOperation("replace", "/spec/opsState", policy.GameServerOpsState))
+		if len(policy.JsonPathConfigs) > 0 {
+			for _, jsonPathConfig := range policy.JsonPathConfigs {
+				patch = append(patch, jsonpatch.NewOperation("replace", jsonPathConfig.JSONPath, jsonPathConfig.Value))
+			}
 		}
+	}
+	if myconfig.JsonPath != nil {
+		patch = append(patch, jsonpatch.NewOperation("replace", *myconfig.JsonPath, data))
 	}
 	return patch
 }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `pkg/store` package, primarily focusing on improving the handling of JSONPath configurations and patch generation logic.

Key changes include:

### Enhancements to JSONPath Configuration:

* [`pkg/store/config.go`](diffhunk://#diff-9cdd0c004a77b4f97fba3fe0fbc7bc1807f0f56e6e68ac32dfa16edb123ed8d1R77-R86): Added a new field `JsonPathConfigs` to the `ProbeMarkerPolicy` struct to support patching JSONPath configurations. Also, added a new `Value` field to the `JSONPathConfig` struct to store the extracted result's value.

### Import and Dependency Management:

* [`pkg/store/in_kube.go`](diffhunk://#diff-88a85426b61b74fa2c56c19dd2af8d3773a401b5b18b49c87f7ecd1de3fac78eR23-L25): Added the `strings` package to the imports section to support string operations.

### Improvements to Patch Generation Logic:

* [`pkg/store/in_kube.go`](diffhunk://#diff-88a85426b61b74fa2c56c19dd2af8d3773a401b5b18b49c87f7ecd1de3fac78eL219-R227): Updated the `generatePatch` function to handle the new `JsonPathConfigs` field in the policy and to apply JSONPath-based patches correctly.